### PR TITLE
Improve README Installation Instructions for Better Reproducibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,21 @@ This codebase builds on [stable-worldmodel](https://github.com/galilai-group/sta
 
 **Installation:**
 ```bash
+# install the stable-worldmodel environment
+git clone https://github.com/galilai-group/stable-worldmodel.git
+cd ./stable-worldmodel
 uv venv --python=3.10
 source .venv/bin/activate
-uv pip install stable-worldmodel[train,env]
+uv sync --all-extras --group dev
+
+cd ../
+git clone https://github.com/lucas-maes/le-wm.git
+cd /le-wm
+source ../stable-worldmodel/.venv/bin/activate
+
+# If the torch version does not match, replace with the correct version via:
+uv pip uninstall torch torchvision torchaudio
+uv pip install --python ../stable-worldmodel/.venv/bin/python --no-cache-dir torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cuxxx
 ```
 
 ## Data


### PR DESCRIPTION
## Summary

This PR improves the installation instructions in the README to ensure a more stable and reproducible setup.


## Background

The current README suggests the following workflow:

```bash
uv venv --python=3.10
source .venv/bin/activate
uv pip install "stable-worldmodel[train,env]"
```

However, this could lead to inconsistent environments and dependency-related issues.


## Issues Identified

### 1. Potential dependency inconsistencies from PyPI installation

Installing `stable-worldmodel[train,env]` from PyPI may introduce mismatched dependency versions (e.g., `stable_pretraining`, `datasets`), which can result in runtime errors such as:

```python
ImportError: cannot import name 'config' from 'datasets'
```


### 2. Deviation from upstream recommended workflows

Upstream projects recommend source-based installation:

* **stable-worldmodel**

  ```bash
  uv sync --all-extras --group dev
  ```

* **stable-pretraining**

  ```bash
  pip install -e .
  ```


## Proposed Update

Use a source-based environment setup aligned with upstream practices, and run this repository directly without installing it as a package.

```bash
git clone https://github.com/galilai-group/stable-worldmodel.git
cd ./stable-worldmodel
uv venv --python=3.10
source .venv/bin/activate
uv sync --all-extras --group dev

cd ../
git clone https://github.com/lucas-maes/le-wm.git
cd /le-wm
source ../stable-worldmodel/.venv/bin/activate
```

Please let me know if you'd prefer an alternative setup or if I can help further refine the installation instructions. Thank you for the amazing work!