### PR TITLE
fix: enable image resize for dino-wm in eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ python eval.py --config-name=pusht.yaml policy=pusht/lewm
 python eval.py --config-name=pusht.yaml policy=pusht/lewm_object.ckpt
 ```
 
+**DINOv2-based models (dinowm):** The `dinowm` model uses a DINOv2-Small backbone (`patch_size=14`) whose predictor has a fixed positional embedding sized for 196 patches (a 14×14 grid). You must set `eval.model_img_size=196` so the backbone receives 196×196 images and produces the expected patch count:
+
+```bash
+python eval.py --config-name=pusht.yaml policy=pusht/dinowm eval.model_img_size=196
+```
+
+Other models (e.g. `lejepa`) are resolution-agnostic and use the default `img_size` (224).
+
 ## Pretrained Checkpoints
 
 Pre-trained checkpoints are available on [Google Drive](https://drive.google.com/drive/folders/1r31os0d4-rR0mdHc7OlY_e5nh3XT4r4e). Download the checkpoint archive and place the extracted files under `$STABLEWM_HOME/`.

--- a/config/eval/cube.yaml
+++ b/config/eval/cube.yaml
@@ -36,6 +36,7 @@ eval:
   goal_offset_steps: 25
   eval_budget: 50
   img_size: 224
+  model_img_size: ${eval.img_size} # override for models that need a different input resolution (e.g. dinowm: 196)
   dataset_name: ogbench/cube_single_expert
   callables:
     # -- set state

--- a/config/eval/pusht.yaml
+++ b/config/eval/pusht.yaml
@@ -31,6 +31,7 @@ eval:
   goal_offset_steps: 25
   eval_budget: 50
   img_size: 224
+  model_img_size: ${eval.img_size} # override for models that need a different input resolution (e.g. dinowm: 196)
   dataset_name: pusht_expert_train
   callables:
     # -- set state

--- a/config/eval/reacher.yaml
+++ b/config/eval/reacher.yaml
@@ -30,6 +30,7 @@ eval:
   goal_offset_steps: 25
   eval_budget: 50
   img_size: 224
+  model_img_size: ${eval.img_size} # override for models that need a different input resolution (e.g. dinowm: 196)
   dataset_name: dmc/reacher_random
   callables:
     # -- set state

--- a/config/eval/tworoom.yaml
+++ b/config/eval/tworoom.yaml
@@ -30,6 +30,7 @@ eval:
   goal_offset_steps: 25
   eval_budget: 50
   img_size: 224
+  model_img_size: ${eval.img_size} # override for models that need a different input resolution (e.g. dinowm: 196)
   dataset_name: tworoom
   callables:
     # -- set state

--- a/eval.py
+++ b/eval.py
@@ -14,13 +14,14 @@ from sklearn import preprocessing
 from torchvision.transforms import v2 as transforms
 import stable_worldmodel as swm
 
-def img_transform(cfg):
+
+def img_transform(img_size):
     transform = transforms.Compose(
         [
             transforms.ToImage(),
             transforms.ToDtype(torch.float32, scale=True),
             transforms.Normalize(**spt.data.dataset_stats.ImageNet),
-            transforms.Resize(size=cfg.eval.img_size),
+            transforms.Resize(size=img_size),
         ]
     )
     return transform
@@ -55,12 +56,12 @@ def run(cfg: DictConfig):
 
     # create world environment
     cfg.world.max_episode_steps = 2 * cfg.eval.eval_budget
-    world = swm.World(**cfg.world, image_shape=(224, 224))
+    world = swm.World(**cfg.world, image_shape=(cfg.eval.img_size, cfg.eval.img_size))
 
     # create the transform
     transform = {
-        "pixels": img_transform(cfg),
-        "goal": img_transform(cfg),
+        "pixels": img_transform(cfg.eval.model_img_size),
+        "goal": img_transform(cfg.eval.model_img_size),
     }
 
     dataset = get_dataset(cfg, cfg.eval.dataset_name)
@@ -85,7 +86,7 @@ def run(cfg: DictConfig):
     policy = cfg.get("policy", "random")
 
     if policy != "random":
-        model = swm.policy.AutoCostModel(cfg.policy)
+        model = swm.policy.AutoCostModel(policy)
         model = model.to("cuda")
         model = model.eval()
         model.requires_grad_(False)
@@ -95,7 +96,6 @@ def run(cfg: DictConfig):
         policy = swm.policy.WorldModelPolicy(
             solver=solver, config=config, process=process, transform=transform
         )
-
     else:
         policy = swm.policy.RandomPolicy()
 


### PR DESCRIPTION
[Problem]
Evaluating policy=pusht/dinowm or pusht/dinowm_noprop failed with shape mismatch in CausalPredictor (pos_embedding length vs sequence length):

File "/home/shawnd/wm/le-wm/.venv/lib/python3.10/site-packages/stable_worldmodel/wm/prejepa.py", line 553, in forward
    x = x + self.pos_embedding[:, :n]
RuntimeError: The size of tensor a (768) must match the size of tensor b (588) at non-singleton dimension 1

The DINOv2 backbone outputs a patch count that depends on input resolution ((H/patch_size)²), while the pretrained predictor’s positional embedding is fixed for a specific patch grid (e.g. 196 patches for 196×196 inputs with patch_size=14). Feeding 224×224 images yields 256 patches per frame, so the flattened history no longer matches the predictor.

[Solution]
Add config:
eval.model_img_size — resolution used in the policy transform (resize before the backbone). Defaults to ${eval.img_size}; for dinowm, override to 196 so patch count matches the checkpoint, which is documented in README.

Only tested pusht, other envs should be the same.