### PR TITLE
Suppress gymnasium non-fatal warnings

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -1,6 +1,16 @@
 import os
+import warnings
 
 os.environ["MUJOCO_GL"] = "egl"
+
+# Suppress Gymnasium non-fatal warnings
+warnings.filterwarnings(
+    "ignore",
+    message=(
+        r".*Casting input x to numpy array"
+    ),
+    category=UserWarning,
+)
 
 import time
 from pathlib import Path


### PR DESCRIPTION
[Problem]
Warning1:
/home/shawnd/wm/le-wm/.venv/lib/python3.10/site-packages/gymnasium/spaces/box.py:424: UserWarning: WARN: Casting input x to numpy array.
  gym.logger.warn("Casting input x to numpy array.")

This is minor issue in gymnasium and therefore simply ignore it.

Warning2:
/home/shawnd/wm/le-wm/.venv/lib/python3.10/site-packages/gymnasium/utils/passive_env_checker.py:158: UserWarning: WARN: The obs returned by the `step()` method is not within the observation space.
  logger.warn(f"{pre} is not within the observation space.")

This is false range check issue from env pusht of stable_worldmodel, proposed [PR](https://github.com/galilai-group/stable-worldmodel/pull/163).