### PR TITLE
Fix eval indexing bug and style issues

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -122,7 +122,7 @@ def run(cfg: DictConfig):
 
     g = np.random.default_rng(cfg.seed)
     random_episode_indices = g.choice(
-        len(valid_indices) - 1, size=cfg.eval.num_eval, replace=False
+        len(valid_indices), size=cfg.eval.num_eval, replace=False
     )
 
     # sort increasingly to avoid issues with HDF5Dataset indexing

--- a/jepa.py
+++ b/jepa.py
@@ -131,9 +131,11 @@ class JEPA(nn.Module):
         assert "goal" in info_dict, "goal not in info_dict"
 
         device = next(self.parameters()).device
-        for k in list(info_dict.keys()):
-            if torch.is_tensor(info_dict[k]):
-                info_dict[k] = info_dict[k].to(device)
+        # Create a copy to avoid modifying the input dict in-place
+        info_dict = {
+            k: (v.to(device) if torch.is_tensor(v) else v)
+            for k, v in info_dict.items()
+        }
 
         goal = {k: v[:, 0] for k, v in info_dict.items() if torch.is_tensor(v)}
         goal["pixels"] = goal["goal"]

--- a/train.py
+++ b/train.py
@@ -72,7 +72,7 @@ def run(cfg):
         dataset, lengths=[cfg.train_split, 1 - cfg.train_split], generator=rnd_gen
     )
 
-    train = torch.utils.data.DataLoader(train_set, **cfg.loader,shuffle=True, drop_last=True, generator=rnd_gen)
+    train = torch.utils.data.DataLoader(train_set, **cfg.loader, shuffle=True, drop_last=True, generator=rnd_gen)
     val = torch.utils.data.DataLoader(val_set, **cfg.loader, shuffle=False, drop_last=False)
     
     ##############################


### PR DESCRIPTION
## Summary
This PR fixes several issues found in the codebase:

### Bug Fixes

1. **eval.py: Fix random indexing bug** (line 124-126)
   - Changed `len(valid_indices) - 1` to `len(valid_indices)`
   - The original code incorrectly excluded the last valid index from being sampled
   - This bug affects the random sampling during evaluation

2. **jepa.py: Fix in-place dict modification in `get_cost` method** (line 134-136)
   - The original code modified the input `info_dict` in-place by moving tensors to device
   - This causes unexpected side effects for the caller since the dictionary is passed by reference
   - Now creates a copy of the dictionary instead

### Style Improvements

3. **train.py: Add missing space after comma** (line 75)
   - Fixed `**cfg.loader,shuffle=True` to `**cfg.loader, shuffle=True`

## Test plan
- [x] Code changes reviewed
- [x] Git history shows clean diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)