### PR TITLE
[Bug] Fix goal_embl dimension

### DIFF
--- a/jepa.py
+++ b/jepa.py
@@ -143,9 +143,9 @@ class JEPA(nn.Module):
                 goal[k[len("goal_") :]] = goal.pop(k)
 
         goal.pop("action")
-        goal = self.encode(goal)
+        goal = self.encode(goal) # (B, T, D)
 
-        info_dict["goal_emb"] = goal["emb"]
+        info_dict["goal_emb"] = goal["emb"].unsqueeze(1)  # (B, 1, T, D) for broadcast
         info_dict = self.rollout(info_dict, action_candidates)
 
         cost = self.criterion(info_dict)


### PR DESCRIPTION
Hello! Thank you for releasing the code!

This PR fixes a shape mismatch in `get_cost()` when passing the goal embedding to the rollout / cost computation.

`self.encode(goal)` returns `goal["emb"]` with shape (B, T, D), but the downstream computation expects the goal embedding to be broadcastable over the action-candidate dimension. Adding unsqueeze(1) makes the shape compatible.

Note:
The original code works without any issues when `B=1` since the broadcast successfully extends the dimensions, but when you set  `B>2`, it breaks the code.