### PR TITLE
Support non-CUDA devices in eval.py and JEPA.get_cost (macOS MPS)

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -86,7 +86,10 @@ def run(cfg: DictConfig):
 
     if policy != "random":
         model = swm.policy.AutoCostModel(cfg.policy)
-        model = model.to("cuda")
+        # Honour cfg.device when set; fall back to CUDA for backward
+        # compatibility with existing configs that don't specify one.
+        device = cfg.get("device", "cuda")
+        model = model.to(device)
         model = model.eval()
         model.requires_grad_(False)
         model.interpolate_pos_encoding = True

--- a/jepa.py
+++ b/jepa.py
@@ -131,9 +131,16 @@ class JEPA(nn.Module):
         assert "goal" in info_dict, "goal not in info_dict"
 
         device = next(self.parameters()).device
+        # Apple's MPS backend does not support float64; downcast any
+        # incoming double tensors (e.g. pusht's float64 proprio/state
+        # observations) before moving them to the device.
+        is_mps = getattr(device, "type", str(device)).startswith("mps")
         for k in list(info_dict.keys()):
-            if torch.is_tensor(info_dict[k]):
-                info_dict[k] = info_dict[k].to(device)
+            t = info_dict[k]
+            if torch.is_tensor(t):
+                if is_mps and t.dtype == torch.float64:
+                    t = t.to(dtype=torch.float32)
+                info_dict[k] = t.to(device)
 
         goal = {k: v[:, 0] for k, v in info_dict.items() if torch.is_tensor(v)}
         goal["pixels"] = goal["goal"]


### PR DESCRIPTION
## Summary

Two small portability fixes that together let `eval.py` run on Apple Silicon
(MPS), CPU, or any other torch device without patching. CUDA users are
unaffected.

1. **`eval.py`**: the cost model is unconditionally moved to CUDA with
   `model.to(\"cuda\")` (line 89), which raises on machines without a CUDA
   device. Read the target device from `cfg.device` and keep `\"cuda\"` as the
   default, so existing configs and training runs are byte-identical.

2. **`jepa.py::JEPA.get_cost`**: environment observations (pusht's `proprio`
   and `state`) are float64, but Apple's MPS backend does not implement
   float64 and raises:

   ```
   TypeError: Cannot convert a MPS Tensor to float64 dtype as the MPS
   framework doesn't support float64. Please use float32 instead.
   ```

   Downcast incoming double tensors to float32 **only when the target device
   is MPS**. CUDA and CPU paths are unchanged.

This composes with the existing `solver.device=...` Hydra override, so a
full Mac eval becomes:

```bash
SDL_VIDEODRIVER=dummy python eval.py --config-name=pusht.yaml \
    policy=pusht/lewm +device=mps solver.device=mps
```

## Reproduction

On macOS (Apple Silicon, torch 2.11 MPS) with the pretrained pusht
checkpoint (via the HF mirror `quentinll/lewm-pusht`, converted to
`$STABLEWM_HOME/pusht/lewm_object.ckpt`), the default eval config
reproduces the paper's headline number exactly:

| Seed | Success rate | Episodes |
|:---:|:---:|:---:|
| 42 (default) | **96.0%** (matches paper) | 48 / 50 |
| 1 | 86.0% | 43 / 50 |
| 7 | 88.0% | 44 / 50 |

CEM solve: ~90-100 s per solve at the paper's `num_samples=300, n_steps=30`
on an M-series Mac.

## Scope

- No behavioural change on CUDA.
- No new dependencies.
- Docstring-only changes + two 2-3 line logic adjustments.
- Related but separate: the checkpoint-location fix is tracked in a
  companion docs PR that surfaces the existing HuggingFace mirror
  (`quentinll/lewm-*`) as the primary download source.