### PR TITLE
docs: surface HuggingFace mirror as the primary checkpoint source

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 **Abstract:** Joint Embedding Predictive Architectures (JEPAs) offer a compelling framework for learning world models in compact latent spaces, yet existing methods remain fragile, relying on complex multi-term losses, exponential moving averages, pretrained encoders, or auxiliary supervision to avoid representation collapse. In this work, we introduce LeWorldModel (LeWM), the first JEPA that trains stably end-to-end from raw pixels using only two loss terms: a next-embedding prediction loss and a regularizer enforcing Gaussian-distributed latent embeddings. This reduces tunable loss hyperparameters from six to one compared to the only existing end-to-end alternative. With ~15M parameters trainable on a single GPU in a few hours, LeWM plans up to 48× faster than foundation-model-based world models while remaining competitive across diverse 2D and 3D control tasks. Beyond control, we show that LeWM's latent space encodes meaningful physical structure through probing of physical quantities. Surprise evaluation confirms that the model reliably detects physically implausible events.
 
 <p align="center">
-   <b>[ <a href="https://arxiv.org/pdf/2603.19312v1">Paper</a> | <a href="https://drive.google.com/drive/folders/1r31os0d4-rR0mdHc7OlY_e5nh3XT4r4e?usp=sharing">Checkpoints</a> | <a href="https://huggingface.co/collections/quentinll/lewm">Data</a> | <a href="https://le-wm.github.io/">Website</a> ]</b>
+   <b>[ <a href="https://arxiv.org/pdf/2603.19312v1">Paper</a> | <a href="https://huggingface.co/collections/quentinll/lewm">Checkpoints &amp; Data</a> | <a href="https://le-wm.github.io/">Website</a> ]</b>
 </p>
 
 <br>
@@ -86,7 +86,16 @@ python eval.py --config-name=pusht.yaml policy=pusht/lewm_object.ckpt
 
 ## Pretrained Checkpoints
 
-Pre-trained checkpoints are available on [Google Drive](https://drive.google.com/drive/folders/1r31os0d4-rR0mdHc7OlY_e5nh3XT4r4e). Download the checkpoint archive and place the extracted files under `$STABLEWM_HOME/`.
+Pretrained LeWM checkpoints for each environment are mirrored on the Hugging Face
+Hub (model repos), alongside the datasets (dataset repos) in the same collection:
+
+- [`quentinll/lewm-pusht`](https://huggingface.co/quentinll/lewm-pusht)
+- [`quentinll/lewm-cube`](https://huggingface.co/quentinll/lewm-cube)
+- [`quentinll/lewm-tworooms`](https://huggingface.co/quentinll/lewm-tworooms)
+- [`quentinll/lewm-reacher`](https://huggingface.co/quentinll/lewm-reacher)
+
+The full baseline checkpoint suite (PLDM, LeJEPA, IVL, IQL, GCBC, DINO-WM, DINO-WM-noprop)
+is available on [Google Drive](https://drive.google.com/drive/folders/1r31os0d4-rR0mdHc7OlY_e5nh3XT4r4e):
 
 <div align="center">
 
@@ -104,11 +113,13 @@ Pre-trained checkpoints are available on [Google Drive](https://drive.google.com
 
 ## Loading a checkpoint
 
+### From the Drive archive
+
 Each tar archive contains two files per checkpoint:
 - `<name>_object.ckpt` — a serialized Python object for convenient loading; this is what `eval.py` and the `stable_worldmodel` API use
 - `<name>_weight.ckpt` — a weights-only checkpoint (`state_dict`) for cases where you want to load weights into your own model instance
 
-To load the object checkpoint via the `stable_worldmodel` API:
+Place the extracted files under `$STABLEWM_HOME/` and load via:
 
 ```python
 import stable_worldmodel as swm
@@ -117,11 +128,57 @@ import stable_worldmodel as swm
 cost = swm.policy.AutoCostModel('pusht/lewm')
 ```
 
-This function accepts:
+`AutoCostModel` accepts:
 - `run_name` — checkpoint path **relative to `$STABLEWM_HOME`**, without the `_object.ckpt` suffix
 - `cache_dir` — optional override for the checkpoint root (defaults to `$STABLEWM_HOME`)
 
 The returned module is in `eval` mode with its PyTorch weights accessible via `.state_dict()`.
+
+### From the Hugging Face mirror
+
+The HF model repos ship the LeWM checkpoint as a `weights.pt` (state dict) plus a
+`config.json` describing the model. Convert once to produce the `_object.ckpt`
+that `eval.py` expects:
+
+```bash
+# download weights.pt + config.json
+hf download quentinll/lewm-pusht --local-dir $STABLEWM_HOME/hf_pusht
+
+# convert to object checkpoint under $STABLEWM_HOME/pusht/lewm_object.ckpt
+python - <<'PY'
+import json, torch, stable_pretraining as spt
+from pathlib import Path
+from jepa import JEPA
+from module import ARPredictor, Embedder, MLP
+import stable_worldmodel as swm
+
+src = Path(swm.data.utils.get_cache_dir(), "hf_pusht")
+out = Path(swm.data.utils.get_cache_dir(), "pusht", "lewm_object.ckpt")
+
+cfg = json.loads((src / "config.json").read_text())
+encoder = spt.backbone.utils.vit_hf(
+    cfg["encoder"]["size"],
+    patch_size=cfg["encoder"]["patch_size"],
+    image_size=cfg["encoder"]["image_size"],
+    pretrained=False, use_mask_token=False,
+)
+mlp = lambda k: MLP(input_dim=cfg[k]["input_dim"], output_dim=cfg[k]["output_dim"],
+                    hidden_dim=cfg[k]["hidden_dim"], norm_fn=torch.nn.BatchNorm1d)
+model = JEPA(
+    encoder=encoder,
+    predictor=ARPredictor(**cfg["predictor"]),
+    action_encoder=Embedder(**cfg["action_encoder"]),
+    projector=mlp("projector"),
+    pred_proj=mlp("pred_proj"),
+)
+sd = torch.load(src / "weights.pt", map_location="cpu", weights_only=False)
+model.load_state_dict(sd, strict=True)
+out.parent.mkdir(parents=True, exist_ok=True)
+torch.save(model, out)
+PY
+```
+
+After conversion, load via `swm.policy.AutoCostModel('pusht/lewm')` as usual.
 
 ## Contact & Contributions
 Feel free to open [issues](https://github.com/lucas-maes/le-wm/issues)! For questions or collaborations, please contact `lucas.maes@mila.quebec`


### PR DESCRIPTION
## Summary

The Google Drive checkpoint folder has been permission-gated for months,
which is the single most common new-user paper cut in this repo (tracked
in #17, #25, #29, #32). Quentin already mirrored the LeWM checkpoints on
the Hugging Face Hub under \`quentinll/lewm-*\` model repos alongside the
datasets, but the README still points to Drive as the only source.

This PR is **docs only** (no code changes) and does three things:

1. **Merge \"Checkpoints\" and \"Data\" into a single header link** pointing
   at the HF collection, since both live in the same
   [\`quentinll/lewm\`](https://huggingface.co/collections/quentinll/lewm)
   collection today.

2. **Rewrite \"Pretrained Checkpoints\"** to surface the four HF model
   repos (\`lewm-pusht\`, \`-cube\`, \`-tworooms\`, \`-reacher\`) as the primary
   download, and keep the Drive link for the baseline-method checkpoints
   (PLDM, LeJEPA, IVL, IQL, GCBC, DINO-WM) that are *not* on HF.

3. **Add a drop-in conversion snippet** under a new \"From the Hugging
   Face mirror\" subsection. The HF model repos ship \`weights.pt\` +
   \`config.json\`, whereas \`eval.py\` and \`swm.policy.AutoCostModel\`
   expect \`<name>_object.ckpt\`. The snippet builds a \`JEPA\` from the
   config, loads the state dict (\`strict=True\`, verified with 0
   missing / 0 unexpected keys on pusht), and saves the object ckpt at
   the expected path so the existing instructions keep working
   unchanged.

After this PR, the happy path for a new user on any machine is:

```bash
hf download quentinll/lewm-pusht --local-dir \$STABLEWM_HOME/hf_pusht
python - <<'PY'
# 20-line conversion snippet from the README
PY
python eval.py --config-name=pusht.yaml policy=pusht/lewm
```

No changes to code, configs, or docstrings.

## Context

This complements (but does not depend on) the non-CUDA device PR in
#50, which makes the eval command above work on macOS MPS and CPU as
well as CUDA.