### PR TITLE
Add torch.compile + bf16 autocast options for inference

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -90,6 +90,27 @@ def run(cfg: DictConfig):
         model = model.eval()
         model.requires_grad_(False)
         model.interpolate_pos_encoding = True
+
+        if cfg.get("compile", False):
+            print("[eval] compiling encoder + predictor (mode=reduce-overhead)")
+            model.encoder = torch.compile(
+                model.encoder, mode="reduce-overhead", dynamic=False)
+            model.predictor = torch.compile(
+                model.predictor, mode="reduce-overhead", dynamic=False)
+
+        if cfg.get("bf16", False):
+            print("[eval] wrapping encode/predict in bf16 autocast")
+            _orig_encode = model.encode
+            _orig_predict = model.predict
+            def _encode_bf16(info):
+                with torch.autocast("cuda", dtype=torch.bfloat16):
+                    return _orig_encode(info)
+            def _predict_bf16(emb, act_emb):
+                with torch.autocast("cuda", dtype=torch.bfloat16):
+                    return _orig_predict(emb, act_emb)
+            model.encode = _encode_bf16
+            model.predict = _predict_bf16
+
         config = swm.PlanConfig(**cfg.plan_config)
         solver = hydra.utils.instantiate(cfg.solver, model=model)
         policy = swm.policy.WorldModelPolicy(


### PR DESCRIPTION
## Summary

Adds two opt-in flags to `eval.py` that recover wall-clock speedup at inference with no algorithmic changes:

- `compile=true` → `torch.compile(mode="reduce-overhead")` on `encoder` + `predictor`
- `bf16=true` → `torch.autocast(bfloat16)` around `encode` / `predict`

Both default to `False`, so existing usage is unchanged.

## Hardware

NVIDIA **H100 NVL** (95 GB), CUDA 13.0, PyTorch 2.11, Python 3.10.

## Speedup (pusht, num_eval=50, 3 seeds = 150 paired episodes)

| metric | `compile=true` | `compile=true bf16=true` |
|---|---|---|
| steady-state CEM solve | **1.09×** | **1.13×** |
| end-to-end `evaluation_time` (incl. ~5s compile cold start) | 1.07× | 1.11× |

- **Steady-state** = post-warmup model forward speedup (what users feel for long-running workloads)
- **End-to-end** = first-call cold start amortized across the eval (what users feel from one CLI invocation)

## Why micro speedups are larger

Synthetic per-call benchmarks show much higher speedups (e.g. encoder@BS=1: 4.0×, full synthetic CEM solve: 1.55× for fp32 / 2.55× for bf16). These don't translate fully to end-to-end eval because:

1. CEM solver has substantial Python overhead (sampling 300 candidates, sorting topk, refitting Gaussian, host↔device sync) that `torch.compile` cannot accelerate.
2. At `num_envs=50`, model forward sees encoder@BS=50 and predictor@BS=15000 — already mostly compute-bound, where compile's relative advantage shrinks.

The reported 1.09×–1.13× is what users actually see end-to-end.

## Success rate validation (paired McNemar test)

| comparison | agreement | variant wins | baseline wins | p-value |
|---|---|---|---|---|
| `compile=true` vs baseline | 149/150 (99.3%) | 0 | 1 | **1.000** |
| `compile=true bf16=true` vs baseline | 142/150 (94.7%) | 5 | 3 | 0.727 |

Both flag combinations are statistically equivalent to baseline. `compile=true` alone produces nearly bit-identical CEM trajectories (only 1/150 episodes differs across 3 seeds).

## Per-seed success rates

| variant | seed=42 | seed=1 | seed=7 | mean |
|---|---|---|---|---|
| baseline (eager fp32) | 96.0% | 86.0% | 94.0% | 92.0% |
| `compile=true` | 96.0% | 86.0% | 92.0% | 91.3% |
| `compile=true bf16=true` | 98.0% | 88.0% | 94.0% | 93.3% |

## Why opt-in (not default)

Validation here is pusht-only / 3 seeds / single GPU. Other tasks (cube/reacher/tworooms) and additional hardware were not tested. Flipping the default deserves the maintainers' own validation pass, which is easier once the option is shipped.

## Usage

```bash
# baseline (unchanged)
python eval.py --config-name=pusht.yaml policy=pusht/lewm

# 1.09× CEM, statistically equivalent to baseline
python eval.py --config-name=pusht.yaml policy=pusht/lewm +compile=true

# 1.13× CEM, ~0.5% cost drift (no observed degradation in 150 episodes)
python eval.py --config-name=pusht.yaml policy=pusht/lewm +compile=true +bf16=true
