### PR TITLE
Fix Checkpoint Loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,37 +145,7 @@ that `eval.py` expects:
 hf download quentinll/lewm-pusht --local-dir $STABLEWM_HOME/hf_pusht
 
 # convert to object checkpoint under $STABLEWM_HOME/pusht/lewm_object.ckpt
-python - <<'PY'
-import json, torch, stable_pretraining as spt
-from pathlib import Path
-from jepa import JEPA
-from module import ARPredictor, Embedder, MLP
-import stable_worldmodel as swm
-
-src = Path(swm.data.utils.get_cache_dir(), "hf_pusht")
-out = Path(swm.data.utils.get_cache_dir(), "pusht", "lewm_object.ckpt")
-
-cfg = json.loads((src / "config.json").read_text())
-encoder = spt.backbone.utils.vit_hf(
-    cfg["encoder"]["size"],
-    patch_size=cfg["encoder"]["patch_size"],
-    image_size=cfg["encoder"]["image_size"],
-    pretrained=False, use_mask_token=False,
-)
-mlp = lambda k: MLP(input_dim=cfg[k]["input_dim"], output_dim=cfg[k]["output_dim"],
-                    hidden_dim=cfg[k]["hidden_dim"], norm_fn=torch.nn.BatchNorm1d)
-model = JEPA(
-    encoder=encoder,
-    predictor=ARPredictor(**cfg["predictor"]),
-    action_encoder=Embedder(**cfg["action_encoder"]),
-    projector=mlp("projector"),
-    pred_proj=mlp("pred_proj"),
-)
-sd = torch.load(src / "weights.pt", map_location="cpu", weights_only=False)
-model.load_state_dict(sd, strict=True)
-out.parent.mkdir(parents=True, exist_ok=True)
-torch.save(model, out)
-PY
+python load_weights.py --dataset=pusht
 ```
 
 After conversion, load via `swm.policy.AutoCostModel('pusht/lewm')` as usual.

--- a/load_weights.py
+++ b/load_weights.py
@@ -29,6 +29,13 @@ def load_hf_checkpoint(dataset="pusht"):
             norm_fn=torch.nn.BatchNorm1d,
         )
 
+    # Make sure format of config file is correct
+    try:
+        del cfg["predictor"]["_target_"]
+        del cfg["action_encoder"]["_target_"]
+    except KeyError:
+        print("Config file is already in the correct format.")
+
     model = JEPA(
         encoder=encoder,
         predictor=ARPredictor(**cfg["predictor"]),

--- a/load_weights.py
+++ b/load_weights.py
@@ -1,0 +1,82 @@
+import json
+import torch
+import stable_pretraining as spt
+from pathlib import Path
+from jepa import JEPA
+from module import ARPredictor, Embedder, MLP
+import stable_worldmodel as swm
+import argparse
+
+
+def load_hf_checkpoint(dataset="pusht"):
+    src = Path(swm.data.utils.get_cache_dir(), f"hf_{dataset}")
+    out = Path(swm.data.utils.get_cache_dir(), dataset, "lewm_object.ckpt")
+
+    cfg = json.loads((src / "config.json").read_text())
+    encoder = spt.backbone.utils.vit_hf(
+        cfg["encoder"]["size"],
+        patch_size=cfg["encoder"]["patch_size"],
+        image_size=cfg["encoder"]["image_size"],
+        pretrained=False,
+        use_mask_token=False,
+    )
+
+    def mlp(k):
+        return MLP(
+            input_dim=cfg[k]["input_dim"],
+            output_dim=cfg[k]["output_dim"],
+            hidden_dim=cfg[k]["hidden_dim"],
+            norm_fn=torch.nn.BatchNorm1d,
+        )
+
+    model = JEPA(
+        encoder=encoder,
+        predictor=ARPredictor(**cfg["predictor"]),
+        action_encoder=Embedder(**cfg["action_encoder"]),
+        projector=mlp("projector"),
+        pred_proj=mlp("pred_proj"),
+    )
+
+    # 1. Load the checkpoint from disk
+    checkpoint = torch.load(src / "weights.pt", map_location="cpu")
+
+    # Extract the actual state dict if it is wrapped in a checkpoint dictionary
+    state_dict = checkpoint.get("state_dict", checkpoint.get("model", checkpoint))
+
+    # 2. Create a new dictionary to hold the translated keys
+    translated_state_dict = {}
+
+    for key, tensor in state_dict.items():
+        new_key = key
+
+        # Target the mismatched ViT layers
+        if "encoder.encoder.layer." in key:
+            # Fix the base layer prefix
+            new_key = new_key.replace("encoder.encoder.layer.", "encoder.layers.")
+
+            # Translate Attention Q, K, V Projections
+            new_key = new_key.replace("attention.attention.query", "attention.q_proj")
+            new_key = new_key.replace("attention.attention.key", "attention.k_proj")
+            new_key = new_key.replace("attention.attention.value", "attention.v_proj")
+
+            # Translate Attention Output
+            new_key = new_key.replace("attention.output.dense", "attention.o_proj")
+
+            # Translate MLP / FeedForward layers
+            new_key = new_key.replace("intermediate.dense", "mlp.fc1")
+            new_key = new_key.replace("output.dense", "mlp.fc2")
+
+        translated_state_dict[new_key] = tensor
+
+    sd = torch.load(src / "weights.pt", map_location="cpu", weights_only=False)  # noqa: F841
+    model.load_state_dict(translated_state_dict, strict=True)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(model, out)
+    print("Successfully saved weights to ", out)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset", type=str, default="pusht")
+    args = parser.parse_args()
+    load_hf_checkpoint(args.dataset)


### PR DESCRIPTION
### Overview
Use newly introduced script for initial weight load and formatting `python load_weights.py --dataset='{BENCHMARK_NAME}'`.

### Issue
Checkpoints can currently not be loaded as per the original README.md. This is due to a set of errors including incompatible Hydra artifacts in the config files (`_target_`), malformed weight object.

#### Incompatible Hydra artifacts
```BASH
13:20:14.897 | INFO    (1067046, stable_pretraining.backbone.utils) | Created ViT-tiny from scratch with config: {'hidden_size': 192, 'num_hidden_layers': 12, 'num_attention_heads': 3, 'intermediate_size': 768, 'image_size': 224, 'patch_size': 14}
13:20:14.897 | ERROR   (1067046, richuru) | Exception:
Traceback (most recent call last):

> File "<stdin>", line 21, in <module>

TypeError: ARPredictor.__init__() got an unexpected keyword argument '_target_'
```

#### Malformed weight object
```BASH
13:24:07.651 | INFO    (1069508, stable_pretraining.backbone.utils) | Created ViT-tiny from scratch with config: {'hidden_size': 192, 'num_hidden_layers': 12, 'num_attention_heads': 3, 'intermediate_size': 768, 'image_size': 224, 'patch_size': 14}
13:24:07.979 | ERROR   (1069508, richuru) | Exception:
Traceback (most recent call last):

> File "<stdin>", line 27, in <module>
  File "$VENV/lib/python3.10/site-packages/torch/nn/modules/module.py", line 2638, in load_state_dict
    raise RuntimeError(

RuntimeError: Error(s) in loading state_dict for JEPA:
        Missing key(s) in state_dict: "encoder.layers.0.attention.q_proj.weight", "encoder.layers.0.attention.q_proj.bias", "encoder.layers.0.attention.k_proj.weight", "encoder.layers.0.attention.k_proj.bias", "encoder.layers.0.attention.v_proj.weight", "encoder.layers.0.attention.v_proj.bias", "encoder.layers.0.attention.o_proj.weight", "encoder.layers.0.attention.o_proj.bias",
...
```

### Fix

#### Incompatible Hydra artifacts
Remove `_target_` from `config.json` in relevant places:
```PYTHON
    # Make sure format of config file is correct
    try:
        del cfg["predictor"]["_target_"]
        del cfg["action_encoder"]["_target_"]
    except KeyError:
        print("Config file is already in the correct format.")
```

#### Malformed weight object
Restructure state dict:
```PYTHON
    for key, tensor in state_dict.items():
        new_key = key

        # Target the mismatched ViT layers
        if "encoder.encoder.layer." in key:
            # Fix the base layer prefix
            new_key = new_key.replace("encoder.encoder.layer.", "encoder.layers.")

            # Translate Attention Q, K, V Projections
            new_key = new_key.replace("attention.attention.query", "attention.q_proj")
            new_key = new_key.replace("attention.attention.key", "attention.k_proj")
            new_key = new_key.replace("attention.attention.value", "attention.v_proj")

            # Translate Attention Output
            new_key = new_key.replace("attention.output.dense", "attention.o_proj")

            # Translate MLP / FeedForward layers
            new_key = new_key.replace("intermediate.dense", "mlp.fc1")
            new_key = new_key.replace("output.dense", "mlp.fc2")

        translated_state_dict[new_key] = tensor

    sd = torch.load(src / "weights.pt", map_location="cpu", weights_only=False)  # noqa: F841
    model.load_state_dict(translated_state_dict, strict=True)
```
