### PR TITLE
Fix off-by-one in eval episode sampling

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -122,8 +122,9 @@ def run(cfg: DictConfig):
 
     g = np.random.default_rng(cfg.seed)
     random_episode_indices = g.choice(
-        len(valid_indices) - 1, size=cfg.eval.num_eval, replace=False
+        len(valid_indices), size=cfg.eval.num_eval, replace=False
     )
+    
 
     # sort increasingly to avoid issues with HDF5Dataset indexing
     random_episode_indices = np.sort(valid_indices[random_episode_indices])


### PR DESCRIPTION
## Summary
In `eval.py`, evaluation start points are sampled with
`g.choice(len(valid_indices) - 1, ...)`. Since `np.random.Generator.choice(N)`
draws from `[0, N)` and the result indexes into `valid_indices`, the `- 1` makes
the last valid start point (`valid_indices[-1]`) unreachable.

The required headroom is already applied upstream via
`max_start_idx = episode_len - goal_offset_steps - 1` and `valid_mask`, so every
entry of `valid_indices` is a legitimate start point at sampling time. Dropping
`- 1` lets the sampler cover the full set.

## Change
`g.choice(len(valid_indices) - 1, ...)` -> `g.choice(len(valid_indices), ...)`

Closes #77.