### PR TITLE
research: quick-burst baseline + tuning on two-room task

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,7 @@
+.venv/
+outputs/
+wandb/
+*.ckpt
+*.h5
+*.zst
+*.lance

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.lab/
+run.log
+.venv/
+__pycache__/
+*.pyc
+outputs/
+wandb/
+*.ckpt
+*.h5
+*.zst

--- a/eval.py
+++ b/eval.py
@@ -98,7 +98,7 @@ def run(cfg: DictConfig):
         model.requires_grad_(False)
         model.interpolate_pos_encoding = True
         config = swm.PlanConfig(**cfg.plan_config)
-        solver = hydra.utils.instantiate(cfg.solver, model=model)
+        solver = hydra.utils.instantiate(cfg.solver, model=model, device=device)
         policy = swm.policy.WorldModelPolicy(
             solver=solver, config=config, process=process, transform=transform
         )

--- a/eval.py
+++ b/eval.py
@@ -14,6 +14,10 @@ from sklearn import preprocessing
 from torchvision.transforms import v2 as transforms
 import stable_worldmodel as swm
 
+from utils import patch_hydra_py314_argparse
+
+patch_hydra_py314_argparse()
+
 def img_transform(cfg):
     transform = transforms.Compose(
         [

--- a/eval.py
+++ b/eval.py
@@ -86,7 +86,10 @@ def run(cfg: DictConfig):
 
     if policy != "random":
         model = swm.wm.utils.load_pretrained(cfg.policy)
-        model = model.to("cuda")
+        device = "cuda" if torch.cuda.is_available() else (
+            "mps" if torch.backends.mps.is_available() else "cpu"
+        )
+        model = model.to(device)
         model = model.eval()
         model.requires_grad_(False)
         model.interpolate_pos_encoding = True

--- a/train.py
+++ b/train.py
@@ -11,7 +11,14 @@ from lightning.pytorch.loggers import WandbLogger
 from omegaconf import OmegaConf, open_dict
 
 from module import SIGReg
-from utils import get_column_normalizer, get_img_preprocessor, SaveCkptCallback
+from utils import (
+    get_column_normalizer,
+    get_img_preprocessor,
+    patch_hydra_py314_argparse,
+    SaveCkptCallback,
+)
+
+patch_hydra_py314_argparse()
 
 
 def lejepa_forward(self, batch, stage, cfg):

--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,24 @@
+import argparse
+
 import numpy as np
 import torch
 from stable_pretraining import data as dt
 from lightning.pytorch.callbacks import Callback
+
+
+def patch_hydra_py314_argparse():
+    """Python 3.14's argparse.HelpFormatter._expand_help does `'%' not in
+    help_string`, which raises TypeError for hydra's non-str LazyCompletionHelp
+    (used for the --shell-completion flag), crashing hydra.main() before any
+    user code runs. Coerce non-str help text to str first."""
+    orig = argparse.HelpFormatter._expand_help
+
+    def _expand_help(self, action):
+        if not isinstance(action.help, str):
+            action.help = str(action.help)
+        return orig(self, action)
+
+    argparse.HelpFormatter._expand_help = _expand_help
 
 def get_img_preprocessor(source: str, target: str, img_size: int = 224):
     imagenet_stats = dt.dataset_stats.ImageNet


### PR DESCRIPTION
## Summary
Draft PR tracking autonomous research commits (Claude Code `researcher` skill session).

Objective: establish a training/eval baseline for LeWM on the two-room control task
(smallest dataset, ~3.4GB, feasible on a single Apple Silicon MPS GPU with no CUDA),
then iterate on hyperparameters/architecture to improve eval performance — in service
of a general JEPA-style ("LeCun-ist") world model usable for planning across environments.

## Results

| Run | Config | val/pred_loss | Planning success_rate (30 ep, CEM) |
|---|---|---|---|
| baseline | 1000 steps (5 epochs x 200 batches, bs=32) | 0.0529 | 80.0% |
| **best** | 2000 steps (10 epochs x 200 batches, bs=32) | 0.0214 | **96.7%** |

Doubling the quick-burst training budget was the single biggest lever tested so far —
the 1000-step baseline was meaningfully under-trained.

## Fixes included (needed to run this codebase on Python 3.14 / Apple Silicon at all)
- `eval.py`: `.to("cuda")` hardcoded → auto-detect cuda/mps/cpu
- `eval.py` + `config/eval/solver/cem.yaml`: CEM solver's `torch.Generator(device="cuda")`
  hardcoded → pass the auto-detected device through `hydra.utils.instantiate`
- `utils.py`: Python 3.14's stricter `argparse.HelpFormatter._expand_help` crashes on
  hydra 1.3.5's non-str `LazyCompletionHelp` (used for `--shell-completion`), which
  otherwise crashes `hydra.main()` before any user code runs on this Python version

Each commit corresponds to one logged, kept experiment (see `.lab/` locally — untracked,
it's the research lab notebook). This is a draft and not intended to merge upstream
as-is; it's for tracking iteration on a fork.

🤖 Generated with a Claude Code `researcher` skill session.